### PR TITLE
Refactor: Change CreateAuditTablesForExistingTables do not inherit from Base but instantiate instances of CreateNewAuditTable for each iteration through the loop

### DIFF
--- a/lib/create_audit_tables_for_existing_tables.rb
+++ b/lib/create_audit_tables_for_existing_tables.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 module AuditTables
-  class CreateAuditTablesForExistingTables < Base
+  class CreateAuditTablesForExistingTables
     attr_reader :klasses
 
     def initialize
@@ -11,10 +11,7 @@ module AuditTables
     def process
       klasses.each do |klass|
         AuditTables::BuildAuditTrigger.new(klass).build
-        @table_name = klass
-        @klass = klass.classify.safe_constantize
-        @audit_table_name = "audit_#{klass}"
-        sync_audit_tables
+        AuditTables::CreateNewAuditTable.new(klass).build
       end
     end
   end


### PR DESCRIPTION
https://syncordiahealth.atlassian.net/browse/CET-536

- [x] Change CreateAuditTablesForExistingTables do not inherit from Base but instantiate instances of CreateNewAuditTable for each iteration through the loop